### PR TITLE
Added support for embed links to DownloadUrlResolver

### DIFF
--- a/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
+++ b/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
@@ -250,7 +250,8 @@ namespace YoutubeExtractor
 
             url = url.Replace("youtu.be/", "youtube.com/watch?v=");
             url = url.Replace("www.youtube", "youtube");
-
+            url = url.Replace("youtube.com/embed/", "youtube.com/watch?v=");
+            
             if (url.Contains("/v/"))
             {
                 url = "http://youtube.com" + new Uri(url).AbsolutePath.Replace("/v/", "/watch?v=");


### PR DESCRIPTION
A little change that allows links taken from embed pages to be used without any manipulation to them directly into DownloadUrlResolver.
