### PR TITLE
Adding small amount of unit tests for DownloadUrlResolver.

### DIFF
--- a/YoutubeExtractor/YoutubeExtractor.Tests/DownloadUrlResolverTest.cs
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/DownloadUrlResolverTest.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using YoutubeExtractor;
+
+namespace YoutubeExtractor.Tests
+{
+    /// <summary>
+    /// Small series of unit tests for DownloadUrlResolver. Run these with NUnit.
+    /// </summary>
+    [TestFixture]
+    public class DownloadUrlResolverTest
+    {        
+        [Test]
+        public void TryNormalizedUrlForStandardYouTubeUrlShouldReturnSame()
+        {
+            string url = "http://youtube.com/watch?v=12345";            
+            
+            string normalizedUrl = String.Empty;
+
+            Assert.IsTrue(DownloadUrlResolver.TryNormalizeYoutubeUrl(url, out normalizedUrl));
+            Assert.AreEqual(url, normalizedUrl);
+        }
+        
+        [Test]
+        public void TryNormalizedrlForYouTuDotBeUrlShouldReturnNormalizedUrl()
+        {
+            string url = "http://youtu.be/12345";
+            
+            string normalizedUrl = String.Empty;
+            Assert.IsTrue(DownloadUrlResolver.TryNormalizeYoutubeUrl(url, out normalizedUrl));
+            Assert.AreEqual("http://youtube.com/watch?v=12345", normalizedUrl);
+        }
+        
+        [Test]
+        public void TryNormalizedUrlForMobileLinkShouldReturnNormalizedUrl()
+        {
+            string url = "http://m.youtube.com/?v=12345";
+            
+            string normalizedUrl = String.Empty;
+            Assert.IsTrue(DownloadUrlResolver.TryNormalizeYoutubeUrl(url, out normalizedUrl));
+
+            Assert.AreEqual("http://youtube.com/watch?v=12345", normalizedUrl);
+        }
+        
+        [Test]
+        public void GetNormalizedYouTubeUrlForBadLinkShouldReturnNull()
+        {
+            string url = "http://notAYouTubeUrl.com";
+           
+            string normalizedUrl = String.Empty;
+            Assert.IsFalse(DownloadUrlResolver.TryNormalizeYoutubeUrl(url, out normalizedUrl));
+            Assert.IsNull(normalizedUrl);
+        }
+    }
+}

--- a/YoutubeExtractor/YoutubeExtractor.Tests/Properties/AssemblyInfo.cs
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("YoutubeExtractor.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("YoutubeExtractor.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d3dc4895-ef34-4c2f-b2b1-5b9ff8b5635d")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/YoutubeExtractor/YoutubeExtractor.Tests/YoutubeExtractor.Tests.csproj
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/YoutubeExtractor.Tests.csproj
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>YoutubeExtractor.Tests</RootNamespace>
+    <AssemblyName>YoutubeExtractor.Tests</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="DownloadUrlResolverTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YoutubeExtractor\YoutubeExtractor.csproj">
+      <Project>{ecdc127f-8def-4f99-8300-72c13597339d}</Project>
+      <Name>YoutubeExtractor</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/YoutubeExtractor/YoutubeExtractor.Tests/packages.config
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net35" />
+</packages>

--- a/YoutubeExtractor/YoutubeExtractor.sln
+++ b/YoutubeExtractor/YoutubeExtractor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.30501.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeExtractor", "YoutubeExtractor\YoutubeExtractor.csproj", "{ECDC127F-8DEF-4F99-8300-72C13597339D}"
 EndProject
@@ -19,10 +19,9 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApplication.Portable
 		{1BB4CF4D-3617-4A23-B51A-DA7711E6F8EB} = {1BB4CF4D-3617-4A23-B51A-DA7711E6F8EB}
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeExtractor.Tests", "YoutubeExtractor.Tests\YoutubeExtractor.Tests.csproj", "{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}"
+EndProject
 Global
-	GlobalSection(CodealikeProperties) = postSolution
-		SolutionGuid = 09b3acc1-9c76-4060-a18f-5b5f253925cc
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -45,8 +44,15 @@ Global
 		{D71C979F-7F55-4AD3-854C-7F1FFF35B4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D71C979F-7F55-4AD3-854C-7F1FFF35B4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D71C979F-7F55-4AD3-854C-7F1FFF35B4F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CE76B74C-BD0C-4768-8F8B-78E0FBD46FBC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(CodealikeProperties) = postSolution
+		SolutionGuid = 09b3acc1-9c76-4060-a18f-5b5f253925cc
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
I thought I'd add a few unit tests to get started, and can continue adding unit tests (along with anyone else) to quickly make sure that we're not breaking any existing functionality as we work on YoutubeExtractor. This requires NUnit to run the tests, which is added via NuGet.
