### PR TITLE
Added mock unit test for testing progress events in videodownloader

### DIFF
--- a/YoutubeExtractor/ExampleApplication/Program.cs
+++ b/YoutubeExtractor/ExampleApplication/Program.cs
@@ -76,7 +76,11 @@ namespace ExampleApplication
                 RemoveIllegalPathCharacters(video.Title) + video.VideoExtension));
 
             // Register the ProgressChanged event and print the current progress
-            videoDownloader.DownloadProgressChanged += (sender, args) => Console.WriteLine(args.ProgressPercentage);
+            videoDownloader.DownloadProgressChanged += (sender, args) =>
+                            Console.WriteLine(string.Format("Downloaded Percentage: {0}, Bytes: {1} , Total bytes : {2}",
+                                                args.ProgressPercentage,
+                                                args.ProgressBytes,
+                                                videoDownloader.DownloadSize));
 
             /*
              * Execute the video downloader.

--- a/YoutubeExtractor/YoutubeExtractor.Tests/VideoDownloaderTest.cs
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/VideoDownloaderTest.cs
@@ -18,8 +18,8 @@ namespace YoutubeExtractor.Tests
         private Mock<VideoDownloader> _videoDownloader;
         private Mock<EventHandler<ProgressEventArgs>> _videoDownloadProgressChanged;
         private Mock<EventHandler> _videoDownloadStarted, _videoDownloadFinished;
-        private Mock<VideoInfo> _videoInfo;
-        private Mock<String> _savePath;
+        private string _mockedSavePath = @"\\somepath\file.ext";
+        private string _mockedYoutubeLink = @"https://www.youtube.com/watch?v=LY_rMXXuJp8";
         #region [Setup / TearDown]
        
 
@@ -29,8 +29,8 @@ namespace YoutubeExtractor.Tests
         [SetUp]
         public void InitializeVideoDownloader()
         {
-            IEnumerable<VideoInfo> vids = DownloadUrlResolver.GetDownloadUrls("https://www.youtube.com/watch?v=LY_rMXXuJp8");
-            _videoDownloader = new Mock<VideoDownloader>(vids.FirstOrDefault(), @"D:\somepath", null);
+            IEnumerable<VideoInfo> vids = DownloadUrlResolver.GetDownloadUrls(_mockedYoutubeLink);
+            _videoDownloader = new Mock<VideoDownloader>(vids.FirstOrDefault(), _mockedSavePath, null);
             _videoDownloadProgressChanged = new Mock<EventHandler<ProgressEventArgs>>();
             _videoDownloadStarted = new Mock<EventHandler>();
             _videoDownloadFinished = new Mock<EventHandler>();
@@ -75,6 +75,7 @@ namespace YoutubeExtractor.Tests
             _videoDownloader.Object.Execute();
             _videoDownloadFinished.Verify();
         }
+
         #endregion
     }
 }

--- a/YoutubeExtractor/YoutubeExtractor.Tests/VideoDownloaderTest.cs
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/VideoDownloaderTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using YoutubeExtractor;
+using Moq;
+
+namespace YoutubeExtractor.Tests
+{
+    /// <summary>
+    /// Test suite for VideoDownloader
+    /// </summary>
+    [TestFixture]
+    public class VideoDownloaderTest
+    {
+
+        private Mock<VideoDownloader> _videoDownloader;
+        private Mock<EventHandler<ProgressEventArgs>> _videoDownloadProgressChanged;
+        private Mock<EventHandler> _videoDownloadStarted, _videoDownloadFinished;
+        private Mock<VideoInfo> _videoInfo;
+        private Mock<String> _savePath;
+        #region [Setup / TearDown]
+       
+
+        /// <summary>
+        /// Initialization for mock objects.
+        /// </summary>
+        [SetUp]
+        public void InitializeVideoDownloader()
+        {
+            IEnumerable<VideoInfo> vids = DownloadUrlResolver.GetDownloadUrls("https://www.youtube.com/watch?v=LY_rMXXuJp8");
+            _videoDownloader = new Mock<VideoDownloader>(vids.FirstOrDefault(), @"D:\somepath", null);
+            _videoDownloadProgressChanged = new Mock<EventHandler<ProgressEventArgs>>();
+            _videoDownloadStarted = new Mock<EventHandler>();
+            _videoDownloadFinished = new Mock<EventHandler>();
+            _videoDownloader.Object.DownloadStarted += _videoDownloadStarted.Object;
+            _videoDownloader.Object.DownloadFinished += _videoDownloadFinished.Object;
+            _videoDownloader.Object.DownloadProgressChanged += _videoDownloadProgressChanged.Object;
+        }
+
+        /// <summary>
+        /// Clean up used resource.
+        /// </summary>
+        [TearDown]
+        public void Cleanup()
+        {
+            _videoDownloader = null;
+            _videoDownloadStarted = null;
+            _videoDownloadProgressChanged = null;
+            _videoDownloadFinished = null;
+        }
+        #endregion
+
+        #region "Actual Test"
+        
+        [Test]
+        public void CheckIfVideoDownloadStartEventIsCalled()
+        {
+            _videoDownloader.Object.Execute();
+            _videoDownloadStarted.Verify();
+        }
+
+        [Test]
+        public void CheckIfVideoDownloadProgressEventIsCalled()
+        {
+            _videoDownloader.Object.Execute();
+            _videoDownloadProgressChanged.Verify();
+        }
+
+
+        [Test]
+        public void CheckIfVideoDownloadEndEventIsCalled()
+        {
+            _videoDownloader.Object.Execute();
+            _videoDownloadFinished.Verify();
+        }
+        #endregion
+    }
+}

--- a/YoutubeExtractor/YoutubeExtractor.Tests/YoutubeExtractor.Tests.csproj
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/YoutubeExtractor.Tests.csproj
@@ -31,6 +31,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1507.0118\lib\net35\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
@@ -45,6 +48,7 @@
   <ItemGroup>
     <Compile Include="DownloadUrlResolverTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VideoDownloaderTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/YoutubeExtractor/YoutubeExtractor.Tests/packages.config
+++ b/YoutubeExtractor/YoutubeExtractor.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1507.0118" targetFramework="net35" />
   <package id="NUnit" version="2.6.3" targetFramework="net35" />
 </packages>

--- a/YoutubeExtractor/YoutubeExtractor/AudioDownloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/AudioDownloader.cs
@@ -102,7 +102,7 @@ namespace YoutubeExtractor
                 {
                     if (this.AudioExtractionProgressChanged != null)
                     {
-                        this.AudioExtractionProgressChanged(this, new ProgressEventArgs(args.ProgressPercentage));
+                        this.AudioExtractionProgressChanged(this, new ProgressEventArgs(args.ProgressPercentage, args.ProgressBytes));
                     }
                 };
 

--- a/YoutubeExtractor/YoutubeExtractor/Downloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/Downloader.cs
@@ -53,6 +53,11 @@ namespace YoutubeExtractor
         public VideoInfo Video { get; private set; }
 
         /// <summary>
+        /// Gets total size of video/audio.
+        /// </summary>
+        public long DownloadSize { get; set; }
+        
+        /// <summary>
         /// Starts the work of the <see cref="Downloader"/>.
         /// </summary>
         public abstract void Execute();

--- a/YoutubeExtractor/YoutubeExtractor/FlvFile.cs
+++ b/YoutubeExtractor/YoutubeExtractor/FlvFile.cs
@@ -93,7 +93,7 @@ namespace YoutubeExtractor
 
                 if (this.ConversionProgressChanged != null)
                 {
-                    this.ConversionProgressChanged(this, new ProgressEventArgs(progress));
+                    this.ConversionProgressChanged(this, new ProgressEventArgs(progress, (int)this.fileOffset));
                 }
             }
 

--- a/YoutubeExtractor/YoutubeExtractor/ProgressEventArgs.cs
+++ b/YoutubeExtractor/YoutubeExtractor/ProgressEventArgs.cs
@@ -4,9 +4,10 @@ namespace YoutubeExtractor
 {
     public class ProgressEventArgs : EventArgs
     {
-        public ProgressEventArgs(double progressPercentage)
+        public ProgressEventArgs(double progressPercentage, int progressBytes)
         {
             this.ProgressPercentage = progressPercentage;
+            this.ProgressBytes = progressBytes;
         }
 
         /// <summary>
@@ -18,5 +19,10 @@ namespace YoutubeExtractor
         /// Gets the progress percentage in a range from 0.0 to 100.0.
         /// </summary>
         public double ProgressPercentage { get; private set; }
+
+        /// <summary>
+        /// Gets the progress bytes from the downloaded video.
+        /// </summary>
+        public int ProgressBytes { get; private set; }
     }
 }

--- a/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
@@ -52,6 +52,7 @@ namespace YoutubeExtractor
                         bool cancel = false;
                         int bytes;
                         int copiedBytes = 0;
+                        this.DownloadSize = response.ContentLength;
 
                         while (!cancel && (bytes = source.Read(buffer, 0, buffer.Length)) > 0)
                         {
@@ -59,7 +60,7 @@ namespace YoutubeExtractor
 
                             copiedBytes += bytes;
 
-                            var eventArgs = new ProgressEventArgs((copiedBytes * 1.0 / response.ContentLength) * 100);
+                            var eventArgs = new ProgressEventArgs((copiedBytes * 1.0 / response.ContentLength) * 100, copiedBytes);
 
                             if (this.DownloadProgressChanged != null)
                             {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,9 @@
 # YoutubeExtractor
 
 <img src="https://ci.appveyor.com/api/projects/status/github/flagbug/youtubeextractor?branch=master&svg=true" alt="build status" />
+[![Nuget](https://img.shields.io/nuget/dt/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
+[![Nuget](https://img.shields.io/nuget/v/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
+[![Nuget](https://img.shields.io/nuget/vpre/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
 
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=daume%2edennis%40gmail%2ecom&lc=US&item_name=YoutubeExtractor&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHostedGuest">
   <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" title="Donate via Paypal" />

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # YoutubeExtractor
 
+<img src="https://ci.appveyor.com/api/projects/status/github/flagbug/youtubeextractor?branch=master&svg=true" alt="build status" />
+
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=daume%2edennis%40gmail%2ecom&lc=US&item_name=YoutubeExtractor&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHostedGuest">
   <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" title="Donate via Paypal" />
 </a>

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,6 @@
 <img src="https://ci.appveyor.com/api/projects/status/github/flagbug/youtubeextractor?branch=master&svg=true" alt="build status" />
 [![Nuget](https://img.shields.io/nuget/dt/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
 [![Nuget](https://img.shields.io/nuget/v/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
-[![Nuget](https://img.shields.io/nuget/vpre/YoutubeExtractor.svg)](https://www.nuget.org/packages/YoutubeExtractor)
 
 <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=daume%2edennis%40gmail%2ecom&lc=US&item_name=YoutubeExtractor&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_LG%2egif%3aNonHostedGuest">
   <img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" title="Donate via Paypal" />


### PR DESCRIPTION
This commit will add a new unit test for *VideoDownloader.cs* . This is core or most important class for this repository. There should be mock unit test case to verify download behaviours. Atleast this will ensure reliability, if there is change in this core class. I have written 3 test cases for verifying *DownloadStarted*, *DownloadProgressChanged*, *DownloadFinished*. I have used [Moq](https://github.com/Moq/moq4) to write those unit test cases. I have mocked *VideoDownloader* class and required events, then I invoked *Execute* and verified whether those events are called.

Since I can't mock static class (VideoInfo) using *Moq*, I have used real youtube link to get instance of VideoInfo. Again, VideoDownloader class needs VideoInfo in constructor and that class is static. I would have used other mocking framework to mock static class, but those are paid. My motive is to test behaviour of download event, that is why I used real youtube link and gone ahead with verifying download events via unit test case.

@flagbug ,please review the changes. Let me know, if this can be merged into [YoutubeExtractor](https://github.com/flagbug/YoutubeExtractor) repository.