### PR TITLE
Get rid of adaptive formats check

### DIFF
--- a/YoutubeExtractor/YoutubeExtractor.sln
+++ b/YoutubeExtractor/YoutubeExtractor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeExtractor", "YoutubeExtractor\YoutubeExtractor.csproj", "{ECDC127F-8DEF-4F99-8300-72C13597339D}"
 EndProject
@@ -9,7 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleApplication", "Examp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{973CC298-FE75-4C3B-AD87-43E1A97197FE}"
 	ProjectSection(SolutionItems) = preProject
-		..\Changelog.txt = ..\Changelog.txt
+		..\Changelog.md = ..\Changelog.md
+		..\readme.md = ..\readme.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YoutubeExtractor_Portable", "YoutubeExtractor\YoutubeExtractor_Portable.csproj", "{1BB4CF4D-3617-4A23-B51A-DA7711E6F8EB}"

--- a/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
+++ b/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
@@ -173,8 +173,6 @@ namespace YoutubeExtractor
         private static IEnumerable<ExtractionInfo> ExtractDownloadUrls(JObject json)
         {
             string[] splitByUrls = GetStreamMap(json).Split(',');
-            string[] adaptiveFmtSplitByUrls = GetAdaptiveStreamMap(json).Split(',');
-            splitByUrls = splitByUrls.Concat(adaptiveFmtSplitByUrls).ToArray();
 
             foreach (string s in splitByUrls)
             {
@@ -209,13 +207,6 @@ namespace YoutubeExtractor
 
                 yield return new ExtractionInfo { RequiresDecryption = requiresDecryption, Uri = new Uri(url) };
             }
-        }
-
-        private static string GetAdaptiveStreamMap(JObject json)
-        {
-            JToken streamMap = json["args"]["adaptive_fmts"];
-
-            return streamMap.ToString();
         }
 
         private static string GetDecipheredSignature(string htmlPlayerVersion, string signature)
@@ -265,8 +256,7 @@ namespace YoutubeExtractor
 
                 if (info != null)
                 {
-                    info = new VideoInfo(info)
-                    {
+                    info = new VideoInfo(info) {
                         DownloadUrl = extractionInfo.Uri.ToString(),
                         Title = videoTitle,
                         RequiresDecryption = extractionInfo.RequiresDecryption
@@ -275,8 +265,7 @@ namespace YoutubeExtractor
 
                 else
                 {
-                    info = new VideoInfo(formatCode)
-                    {
+                    info = new VideoInfo(formatCode) {
                         DownloadUrl = extractionInfo.Uri.ToString()
                     };
                 }


### PR DESCRIPTION
- Fix "Could not parse the Youtube page for URL" (https://github.com/flagbug/YoutubeExtractor/issues/139). Indeed their JSON changed and we no longer have `["args"]["adaptive_fmts"]`

Original credit: https://github.com/tariqalkhassa/YoutubeExtractor/commit/3fbf982ab175625ee77af3567c6543b126189a49 (see https://github.com/flagbug/YoutubeExtractor/issues/119)