### PR TITLE
Fixes #194

### DIFF
--- a/YoutubeExtractor/ExampleApplication/Program.cs
+++ b/YoutubeExtractor/ExampleApplication/Program.cs
@@ -88,7 +88,7 @@ namespace ExampleApplication
         private static void Main()
         {
             // Our test youtube link
-            const string link = "http://www.youtube.com/watch?v=O3UBOOZw-FE";
+            const string link = "https://www.youtube.com/watch?v=YQHsXMglC9A";
 
             /*
              * Get the available video formats.

--- a/YoutubeExtractor/YoutubeExtractor/Decipherer.cs
+++ b/YoutubeExtractor/YoutubeExtractor/Decipherer.cs
@@ -22,7 +22,7 @@ namespace YoutubeExtractor
                 funcName = "\\" + funcName; //Due To Dollar Sign Introduction, Need To Escape
             }
 
-            string funcPattern = @funcName + @"=function\(\w+\)\{.*?\},"; //Escape funcName string
+            string funcPattern = @"(?!h\.)" + @funcName + @"=function\(\w+\)\{.*?\}"; //Escape funcName string
             var funcBody = Regex.Match(js, funcPattern, RegexOptions.Singleline).Value; //Entire sig function
             var lines = funcBody.Split(';'); //Each line in sig function
 

--- a/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
+++ b/YoutubeExtractor/YoutubeExtractor/DownloadUrlResolver.cs
@@ -13,7 +13,6 @@ namespace YoutubeExtractor
     public static class DownloadUrlResolver
     {
         private const string RateBypassFlag = "ratebypass";
-        private const int CorrectSignatureLength = 81;
         private const string SignatureQuery = "signature";
 
         /// <summary>
@@ -226,11 +225,6 @@ namespace YoutubeExtractor
 
         private static string GetDecipheredSignature(string htmlPlayerVersion, string signature)
         {
-            if (signature.Length == CorrectSignatureLength)
-            {
-                return signature;
-            }
-
             return Decipherer.DecipherWithVersion(signature, htmlPlayerVersion);
         }
 


### PR DESCRIPTION
Youtube changed their signature script again which resulted in regex to match the `funcBody`, the updated regex takes care of that.  
Also updated test URL to some vevo music video, which always triggers the `CecipherWithversion()` method.