### PR TITLE
Added support for Vorbis video, Opus audio and 60fps

### DIFF
--- a/YoutubeExtractor/YoutubeExtractor/AudioDownloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/AudioDownloader.cs
@@ -102,7 +102,7 @@ namespace YoutubeExtractor
                 {
                     if (this.AudioExtractionProgressChanged != null)
                     {
-                        this.AudioExtractionProgressChanged(this, new ProgressEventArgs(args.ProgressPercentage));
+                        this.AudioExtractionProgressChanged(this, args);
                     }
                 };
 

--- a/YoutubeExtractor/YoutubeExtractor/AudioType.cs
+++ b/YoutubeExtractor/YoutubeExtractor/AudioType.cs
@@ -5,6 +5,7 @@
         Aac,
         Mp3,
         Vorbis,
+        Opus,
 
         /// <summary>
         /// The audio type is unknown. This can occur if YoutubeExtractor is not up-to-date.

--- a/YoutubeExtractor/YoutubeExtractor/Decipherer.cs
+++ b/YoutubeExtractor/YoutubeExtractor/Decipherer.cs
@@ -13,7 +13,7 @@ namespace YoutubeExtractor
             string js = HttpHelper.DownloadString(jsUrl);
 
             //Find "C" in this: var A = B.sig||C (B.s)
-            string functNamePattern = @"\.sig\s*\|\|([a-zA-Z0-9\$]+)\("; //Regex Formed To Find Word or DollarSign
+            string functNamePattern = @"\""signature"",\s?([a-zA-Z0-9\$]+)\(";
 
             var funcName = Regex.Match(js, functNamePattern).Groups[1].Value;
             

--- a/YoutubeExtractor/YoutubeExtractor/FlvFile.cs
+++ b/YoutubeExtractor/YoutubeExtractor/FlvFile.cs
@@ -93,7 +93,7 @@ namespace YoutubeExtractor
 
                 if (this.ConversionProgressChanged != null)
                 {
-                    this.ConversionProgressChanged(this, new ProgressEventArgs(progress));
+                    this.ConversionProgressChanged(this, new ProgressEventArgs((int)this.fileOffset, progress));
                 }
             }
 

--- a/YoutubeExtractor/YoutubeExtractor/ProgressEventArgs.cs
+++ b/YoutubeExtractor/YoutubeExtractor/ProgressEventArgs.cs
@@ -4,8 +4,9 @@ namespace YoutubeExtractor
 {
     public class ProgressEventArgs : EventArgs
     {
-        public ProgressEventArgs(double progressPercentage)
+        public ProgressEventArgs(int progressBytes, double progressPercentage)
         {
+            this.ProgressBytes = progressBytes;
             this.ProgressPercentage = progressPercentage;
         }
 
@@ -13,6 +14,11 @@ namespace YoutubeExtractor
         /// Gets or sets a token whether the operation that reports the progress should be canceled.
         /// </summary>
         public bool Cancel { get; set; }
+
+        /// <summary>
+        /// Gets the progress in bytes downloaded.
+        /// </summary>
+        public int ProgressBytes { get; private set; }
 
         /// <summary>
         /// Gets the progress percentage in a range from 0.0 to 100.0.

--- a/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
@@ -51,6 +51,7 @@ namespace YoutubeExtractor
             {
                 using (Stream source = response.GetResponseStream())
                 {
+                    DownloadSize = (int)response.ContentLength;
                     using (FileStream target = File.Open(this.SavePath, FileMode.Create, FileAccess.Write))
                     {
                         var buffer = new byte[1024];

--- a/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
+++ b/YoutubeExtractor/YoutubeExtractor/VideoDownloader.cs
@@ -26,6 +26,11 @@ namespace YoutubeExtractor
         public event EventHandler<ProgressEventArgs> DownloadProgressChanged;
 
         /// <summary>
+        /// Returns the size of the current download in bytes.
+        /// </summary>
+        public int DownloadSize { get; private set; }
+
+        /// <summary>
         /// Starts the video download.
         /// </summary>
         /// <exception cref="IOException">The video file could not be saved.</exception>
@@ -59,7 +64,7 @@ namespace YoutubeExtractor
 
                             copiedBytes += bytes;
 
-                            var eventArgs = new ProgressEventArgs((copiedBytes * 1.0 / response.ContentLength) * 100);
+                            var eventArgs = new ProgressEventArgs(copiedBytes, (copiedBytes * 1.0 / response.ContentLength) * 100);
 
                             if (this.DownloadProgressChanged != null)
                             {

--- a/YoutubeExtractor/YoutubeExtractor/VideoInfo.cs
+++ b/YoutubeExtractor/YoutubeExtractor/VideoInfo.cs
@@ -49,24 +49,39 @@ namespace YoutubeExtractor
             new VideoInfo(271, VideoType.WebM, 1440, false, AudioType.Unknown, 0, AdaptiveType.Video),
             new VideoInfo(272, VideoType.WebM, 2160, false, AudioType.Unknown, 0, AdaptiveType.Video),
             new VideoInfo(278, VideoType.WebM, 144, false, AudioType.Unknown, 0, AdaptiveType.Video),
+            new VideoInfo(302, VideoType.WebM, 720, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(303, VideoType.WebM, 1080, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(308, VideoType.WebM, 1440, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(313, VideoType.WebM, 2160, false, AudioType.Unknown, 0, AdaptiveType.Video),
+            new VideoInfo(315, VideoType.WebM, 2160, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(298, VideoType.Mp4, 720, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(299, VideoType.Mp4, 1080, false, AudioType.Unknown, 0, AdaptiveType.Video, 60),
+            new VideoInfo(266, VideoType.Mp4, 2160, false, AudioType.Unknown, 0, AdaptiveType.Video),
 
             /* Adaptive (aka DASH) - Audio */
             new VideoInfo(139, VideoType.Mp4, 0, false, AudioType.Aac, 48, AdaptiveType.Audio),
             new VideoInfo(140, VideoType.Mp4, 0, false, AudioType.Aac, 128, AdaptiveType.Audio),
             new VideoInfo(141, VideoType.Mp4, 0, false, AudioType.Aac, 256, AdaptiveType.Audio),
             new VideoInfo(171, VideoType.WebM, 0, false, AudioType.Vorbis, 128, AdaptiveType.Audio),
-            new VideoInfo(172, VideoType.WebM, 0, false, AudioType.Vorbis, 192, AdaptiveType.Audio)
+            new VideoInfo(172, VideoType.WebM, 0, false, AudioType.Vorbis, 192, AdaptiveType.Audio),
+            new VideoInfo(249, VideoType.WebM, 0, false, AudioType.Opus, 50, AdaptiveType.Audio),
+            new VideoInfo(250, VideoType.WebM, 0, false, AudioType.Opus, 70, AdaptiveType.Audio),
+            new VideoInfo(251, VideoType.WebM, 0, false, AudioType.Opus, 160, AdaptiveType.Audio),
         };
 
         internal VideoInfo(int formatCode)
-            : this(formatCode, VideoType.Unknown, 0, false, AudioType.Unknown, 0, AdaptiveType.None)
+            : this(formatCode, VideoType.Unknown, 0, false, AudioType.Unknown, 0, AdaptiveType.None, 0)
         { }
 
         internal VideoInfo(VideoInfo info)
-            : this(info.FormatCode, info.VideoType, info.Resolution, info.Is3D, info.AudioType, info.AudioBitrate, info.AdaptiveType)
+            : this(info.FormatCode, info.VideoType, info.Resolution, info.Is3D, info.AudioType, info.AudioBitrate, info.AdaptiveType, info.FrameRate)
         { }
 
         private VideoInfo(int formatCode, VideoType videoType, int resolution, bool is3D, AudioType audioType, int audioBitrate, AdaptiveType adaptiveType)
+            : this(formatCode, videoType, resolution, is3D, audioType, audioBitrate, adaptiveType, 0)
+        { }
+
+        private VideoInfo(int formatCode, VideoType videoType, int resolution, bool is3D, AudioType audioType, int audioBitrate, AdaptiveType adaptiveType, int frameRate)
         {
             this.FormatCode = formatCode;
             this.VideoType = videoType;
@@ -75,6 +90,7 @@ namespace YoutubeExtractor
             this.AudioType = audioType;
             this.AudioBitrate = audioBitrate;
             this.AdaptiveType = adaptiveType;
+            this.FrameRate = frameRate;
         }
 
         /// <summary>
@@ -91,6 +107,11 @@ namespace YoutubeExtractor
         /// </summary>
         /// <value>The approximate audio bitrate in kbit/s, or 0 if the bitrate is unknown.</value>
         public int AudioBitrate { get; private set; }
+
+        /// <summary>
+        /// The frame rate of the video, usually 60 or 0 for unspecified.
+        /// </summary>
+        public int FrameRate { get; internal set; }
 
         /// <summary>
         /// Gets the audio extension.
@@ -154,10 +175,15 @@ namespace YoutubeExtractor
         public bool RequiresDecryption { get; internal set; }
 
         /// <summary>
+        /// Gets the size of the stream in bytes.
+        /// </summary>
+        public long FileSize { get; internal set; }
+
+        /// <summary>
         /// Gets the resolution of the video.
         /// </summary>
         /// <value>The resolution of the video, or 0 if the resolution is unkown.</value>
-        public int Resolution { get; private set; }
+        public int Resolution { get; internal set; }
 
         /// <summary>
         /// Gets the video title.

--- a/YoutubeExtractor/YoutubeExtractor/YoutubeExtractor.csproj
+++ b/YoutubeExtractor/YoutubeExtractor/YoutubeExtractor.csproj
@@ -35,12 +35,14 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net35\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\..\NaturalGroundingPlayer\packages\Newtonsoft.Json.9.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Web" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AacAudioExtractor.cs" />

--- a/YoutubeExtractor/YoutubeExtractor/packages.YoutubeExtractor.config
+++ b/YoutubeExtractor/YoutubeExtractor/packages.YoutubeExtractor.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Added support for Vorbis video, Opus audio, 60fps, as well as various HD formats that are only available by parsing the Dash Manifest. Added ProgressEventArgs.ProgressBytes.

Note: since recently, YouTube returns (409) Forbidden. This merge does *not* solve this problem.